### PR TITLE
fix: Build with Clang

### DIFF
--- a/include/common.hpp
+++ b/include/common.hpp
@@ -1,9 +1,15 @@
 #pragma once
 
-#include <experimental/string_view>
 #include <string>
 #include <vector>
 
+#ifdef __clang__
+    #include <string_view>
+    using std::string_view;
+#else
+    #include <experimental/string_view>
+    using std::experimental::string_view;
+#endif
+
 using std::vector;
-using std::experimental::string_view;
 using std::string;


### PR DESCRIPTION
The Clang has the `string_view` header in the path without the experimental directory.